### PR TITLE
Fix build for Debian Bookworm

### DIFF
--- a/src/pcxhr.c
+++ b/src/pcxhr.c
@@ -60,7 +60,6 @@ MODULE_AUTHOR("Gilbert Passador <www.digigram.com>, "
 	      "Loïc Boissy <www.digigram.com>");
 MODULE_DESCRIPTION("Digigram " DRIVER_NAME " " PCXHR_DRIVER_VERSION_STRING);
 MODULE_LICENSE("GPL");
-MODULE_SUPPORTED_DEVICE("{{Digigram," DRIVER_NAME "}}");
 
 static int index[SNDRV_CARDS] = SNDRV_DEFAULT_IDX;	/* Index 0-MAX */
 static char *id[SNDRV_CARDS] = SNDRV_DEFAULT_STR;	/* ID for this card */
@@ -1651,7 +1650,7 @@ static int pcxhr_probe(struct pci_dev *pci,
 	pci_set_master(pci);
 
 	/* check if we can restrict PCI DMA transfers to 32 bits */
-	if (pci_set_dma_mask(pci, DMA_BIT_MASK(32)) < 0) {
+	if (dma_set_mask(&pci->dev, DMA_BIT_MASK(32)) < 0) {
 		snd_printk(KERN_ERR "architecture does not support "
 			   "32bit PCI busmaster DMA\n");
 		pci_disable_device(pci);


### PR DESCRIPTION
The current version of the driver does not work on Debian Bookworm and likely any distro with  kernel version > 5.12
This backports the following changes from the upstream linux kernel:

https://github.com/torvalds/linux/commit/6417f03132a6952cd17ddd8eaddbac92b61b17e0

and

https://github.com/torvalds/linux/commit/412b979ccceff448dccea54bdb616c85781bc0ba#diff-41c258763c379facae6c4d3781f12acd96b3a875746deb169453d8da17d7eb79